### PR TITLE
Use Mongo replicaset

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -32,12 +32,30 @@ services:
     networks:
       - cdp-tenant
 
-  mongodb:
+  mongodb:  
+    # Initialise a Mongo cluster with a replicaset of 1 node.
+    # Based on https://medium.com/workleap/the-only-local-mongodb-replica-set-with-docker-compose-guide-youll-ever-need-2f0b74dd8384
+    # Since we are using transactions, we require a replicaset. Local dev with docker compose uses 1 node below, but our live
+    # environments have multiple nodes.
+    # The replicaset needs initialising, so the healthcheck can be hijacked to initialise this so that it can keep retrying
+    # until the operation is successful (might need to wait a while after container boot for this to work, hence the interval/retries)
+    # WARNING: do not turn on authentication, otherwise will need to deal with generating key pairs and sharing them between
+    # the replicaset nodes. For local development this is overkill, so just turn off auth and connect to Mongo without creds.
     image: mongo:6.0.13
+    command: ["--replSet", "rs0", "--bind_ip_all", "--port", "27017"]
     networks:
       - cdp-tenant
     ports:
-      - '27017:27017'
+      - 27017:27017
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'host.docker.internal:27017'}]}) }" | mongosh --port 27017 --quiet
+      interval: 5s
+      timeout: 30s
+      start_period: 0s
+      start_interval: 1s
+      retries: 30
     volumes:
       - mongodb-data:/data
     restart: always


### PR DESCRIPTION
updated compose file to create a mongo cluster with a replicaset of 1 node, as this is required for transactions.